### PR TITLE
Fixing a bug in SAXDocumentReader.TagHandler

### DIFF
--- a/src/main/java/com/sjl/dsl4xml/SAXDocumentReader.java
+++ b/src/main/java/com/sjl/dsl4xml/SAXDocumentReader.java
@@ -310,7 +310,7 @@ public class SAXDocumentReader<T> extends AbstractDocumentReader<T> {
 			}
 			
 			if (tags == null) {
-				return this;
+				return getIgnore();
 			}
 			
 			for (TagHandler<?> _h : tags) {

--- a/src/test/java/com/sjl/dsl4xml/example/UnknownTagsTest.java
+++ b/src/test/java/com/sjl/dsl4xml/example/UnknownTagsTest.java
@@ -1,0 +1,63 @@
+package com.sjl.dsl4xml.example;
+
+import static com.sjl.dsl4xml.SAXDocumentReader.*;
+
+import java.io.*;
+import java.util.*;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.sjl.dsl4xml.*;
+
+public class UnknownTagsTest {
+	
+	@Test
+	public void processesEmptyInputCorrectly()
+	throws Exception {
+		MainTag mainTag = newMarshaller().read(new StringReader("<mainTag></mainTag>"));
+		Assert.assertEquals(0, mainTag.size());
+	}
+	
+	@Test
+	public void processesUnknownSubTagCorrectly()
+	throws Exception {
+		MainTag mainTag = newMarshaller().read(new StringReader("<mainTag><unknownSubTag>foo</unknownSubTag></mainTag>"));
+		Assert.assertEquals(0, mainTag.size());
+	}
+	
+	@Test
+	public void processesUnknownSubTagWithinTagWithNoTagHandlers()
+	throws Exception {
+		MainTag mainTag = newMarshaller().read(new StringReader("<mainTag><subTag><unknownSubTag>foo</unknownSubTag></subTag></mainTag>"));
+		Assert.assertEquals(1, mainTag.size());
+	}
+	
+	private static SAXDocumentReader<MainTag> newMarshaller() {
+		SAXDocumentReader<MainTag> _result = mappingOf("mainTag", MainTag.class).to(
+			tag("subTag", SubTag.class)
+		);
+		return _result;
+	}
+
+	public static class MainTag {
+		private List<SubTag> subTags;
+		
+		public MainTag() {
+			subTags = new ArrayList<SubTag>();
+		}
+		
+		public void addSubTag(SubTag subTag) {
+			subTags.add(subTag);
+		}
+		
+		public int size() {
+			return subTags.size();
+		}
+	}
+	
+	public static class SubTag {
+		public SubTag() {}
+	}
+}


### PR DESCRIPTION
Fixed a bug that can be triggered in the current trunk version as follows:
1. Create a SAXDocumentReader with a tag handler T that has no subhandlers.
2. Create an XML file where the tag T handled by the above tag handler has some subtags that should be ignored.
3. When parsing the tag T in TagHandler.startTag, the method returns with the same tag handler when it encounters a subtag instead of the ignore handler. This puts the context stack out of sync with the XML tree and sooner or later one will encounter an EmptyStackException when the parser tries to peek into the stack.

This commit fixes the issue by modifying TagHandler to return the ignore handler instead of "this" when a tag handler has no subtag handlers and it encounters a subtag.
